### PR TITLE
feat: make database directories configurable

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/block-builder/config.toml
+++ b/block-builder/config.toml
@@ -16,3 +16,6 @@ algo_id = 0
 computer = ["7c2df8c780d2e0401d7091c54086d228dabad208"]
 verifier = ["3527ab0f9ba36d221d72e02368ca7ddf73c2bc19"]
 users = ["fdc065619e2defb916dca551f85bf7d7a44023ef"]
+
+[database]
+directory = "./local-storage"

--- a/block-builder/src/lib.rs
+++ b/block-builder/src/lib.rs
@@ -5,7 +5,7 @@ use k256::ecdsa::SigningKey;
 use libp2p::{gossipsub, mdns, swarm::SwarmEvent, Swarm};
 use openrank_common::{
     broadcast_event, build_node, config,
-    db::{Db, DbError, DbItem},
+    db::{self, Db, DbError, DbItem},
     result::JobResult,
     topics::{Domain, Topic},
     tx_event::TxEvent,
@@ -42,6 +42,7 @@ pub struct Config {
     pub domains: Vec<Domain>,
     /// The whitelist for the Block Builder.
     pub whitelist: Whitelist,
+    pub database: db::Config,
 }
 
 /// The Block Builder node. It contains the Swarm, the Config, the DB, the SecretKey, and the JobRunner.
@@ -71,7 +72,7 @@ impl BlockBuilderNode {
 
         let config_loader = config::Loader::new("openrank-block-builder")?;
         let config: Config = config_loader.load_or_create(include_str!("../config.toml"))?;
-        let db = Db::new("./local-storage", &[&Tx::get_cf(), &JobResult::get_cf()])?;
+        let db = Db::new(&config.database, &[&Tx::get_cf(), &JobResult::get_cf()])?;
 
         Ok(Self { swarm, config, db, secret_key })
     }

--- a/common/src/db.rs
+++ b/common/src/db.rs
@@ -1,5 +1,5 @@
 use rocksdb::{Error as RocksDBError, Options, DB};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::{to_vec, Error as SerdeError};
 use std::error::Error as StdError;
 use std::fmt::{Display, Formatter, Result as FmtResult};
@@ -16,6 +16,7 @@ pub enum DbError {
     CfNotFound,
     /// Error when entry is not found.
     NotFound,
+    Config(String),
 }
 
 impl StdError for DbError {}
@@ -27,6 +28,7 @@ impl Display for DbError {
             Self::Serde(e) => write!(f, "{}", e),
             Self::CfNotFound => write!(f, "CfNotFound"),
             Self::NotFound => write!(f, "NotFound"),
+            Self::Config(msg) => write!(f, "Config({:?})", msg),
         }
     }
 }
@@ -43,6 +45,18 @@ pub trait DbItem {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Config {
+    directory: String,
+    secondary: Option<String>,
+}
+
+impl Config {
+    fn get_secondary(&self) -> Result<&String, DbError> {
+        self.secondary.as_ref().ok_or(DbError::Config("secondary path not set".into()))
+    }
+}
+
 /// Wrapper for database connection.
 pub struct Db {
     connection: DB,
@@ -50,8 +64,8 @@ pub struct Db {
 
 impl Db {
     /// Creates new database connection, given info of local file path and column families.
-    pub fn new(path: &str, cfs: &[&str]) -> Result<Self, DbError> {
-        assert!(path.ends_with("-storage"));
+    pub fn new(config: &Config, cfs: &[&str]) -> Result<Self, DbError> {
+        let path = &config.directory;
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
@@ -60,8 +74,8 @@ impl Db {
     }
 
     /// Creates new read-only database connection, given info of local file path and column families.
-    pub fn new_read_only(path: &str, cfs: &[&str]) -> Result<Self, DbError> {
-        assert!(path.ends_with("-storage"));
+    pub fn new_read_only(config: &Config, cfs: &[&str]) -> Result<Self, DbError> {
+        let path = &config.directory;
         let db = DB::open_cf_for_read_only(&Options::default(), path, cfs, false)
             .map_err(DbError::RocksDB)?;
         Ok(Self { connection: db })
@@ -69,11 +83,9 @@ impl Db {
 
     /// Creates new secondary database connection, given info of primary and secondary file paths and column families.
     /// Secondary database is used for read-only queries, and should be explicitly refreshed.
-    pub fn new_secondary(
-        primary_path: &str, secondary_path: &str, cfs: &[&str],
-    ) -> Result<Self, DbError> {
-        assert!(primary_path.ends_with("-storage"));
-        assert!(secondary_path.ends_with("-storage"));
+    pub fn new_secondary(config: &Config, cfs: &[&str]) -> Result<Self, DbError> {
+        let primary_path = &config.directory;
+        let secondary_path = config.get_secondary()?;
         let db = DB::open_cf_as_secondary(&Options::default(), primary_path, secondary_path, cfs)
             .map_err(DbError::RocksDB)?;
         Ok(Self { connection: db })
@@ -119,13 +131,17 @@ impl Db {
 
 #[cfg(test)]
 mod test {
-    use super::{Db, DbItem};
+    use super::{Config, Db, DbItem};
     use crate::txs::{JobRunAssignment, JobRunRequest, JobVerification, Tx, TxKind};
     use alloy_rlp::encode;
 
+    fn config_for_dir(directory: &str) -> Config {
+        Config { directory: directory.to_string(), secondary: None }
+    }
+
     #[test]
     fn test_put_get() {
-        let db = Db::new("test-pg-storage", &[&Tx::get_cf()]).unwrap();
+        let db = Db::new(&config_for_dir("test-pg-storage"), &[&Tx::get_cf()]).unwrap();
         let tx = Tx::default_with(TxKind::JobRunRequest, encode(JobRunRequest::default()));
         db.put(tx.clone()).unwrap();
         let key = Tx::construct_full_key(TxKind::JobRunRequest, tx.hash());
@@ -135,7 +151,7 @@ mod test {
 
     #[test]
     fn test_read_from_end() {
-        let db = Db::new("test-rfs-storage", &[&Tx::get_cf()]).unwrap();
+        let db = Db::new(&config_for_dir("test-rfs-storage"), &[&Tx::get_cf()]).unwrap();
         let tx1 = Tx::default_with(TxKind::JobRunRequest, encode(JobRunRequest::default()));
         let tx2 = Tx::default_with(
             TxKind::JobRunAssignment,

--- a/computer/config.toml
+++ b/computer/config.toml
@@ -15,3 +15,6 @@ algo_id = 0
 [whitelist]
 block_builder = ["baf339966e8caa8f47e696b0354b9fcb1186b3f8"]
 verifier = ["3527ab0f9ba36d221d72e02368ca7ddf73c2bc19"]
+
+[database]
+directory = "./local-storage"

--- a/computer/src/lib.rs
+++ b/computer/src/lib.rs
@@ -5,7 +5,7 @@ use k256::ecdsa::SigningKey;
 use libp2p::{gossipsub, mdns, swarm::SwarmEvent, Swarm};
 use openrank_common::{
     address_from_sk, broadcast_event, build_node, config,
-    db::{Db, DbItem},
+    db::{self, Db, DbItem},
     topics::{Domain, Topic},
     tx_event::TxEvent,
     txs::{
@@ -34,6 +34,7 @@ pub struct Whitelist {
 pub struct Config {
     pub domains: Vec<Domain>,
     pub whitelist: Whitelist,
+    pub database: db::Config,
 }
 
 pub struct ComputerNode {
@@ -233,7 +234,7 @@ impl ComputerNode {
 
         let config_loader = config::Loader::new("openrank-computer")?;
         let config: Config = config_loader.load_or_create(include_str!("../config.toml"))?;
-        let db = Db::new("./local-storage", &[&Tx::get_cf()])?;
+        let db = Db::new(&config.database, &[&Tx::get_cf()])?;
 
         let domain_hashes = config.domains.iter().map(|x| x.to_hash()).collect();
         let job_runner = ComputeJobRunner::new(domain_hashes);

--- a/sequencer/config.toml
+++ b/sequencer/config.toml
@@ -1,2 +1,6 @@
 [whitelist]
 users = ["fdc065619e2defb916dca551f85bf7d7a44023ef"]
+
+[database]
+directory = "./local-storage"
+secondary = "./local-secondary-storage"

--- a/verifier/config.toml
+++ b/verifier/config.toml
@@ -15,3 +15,6 @@ algo_id = 0
 [whitelist]
 block_builder = ["baf339966e8caa8f47e696b0354b9fcb1186b3f8"]
 computer = ["7c2df8c780d2e0401d7091c54086d228dabad208"]
+
+[database]
+directory = "./local-storage"

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -5,7 +5,7 @@ use k256::ecdsa::SigningKey;
 use libp2p::{gossipsub, mdns, swarm::SwarmEvent, Swarm};
 use openrank_common::{
     address_from_sk, broadcast_event, build_node, config,
-    db::{Db, DbItem},
+    db::{self, Db, DbItem},
     topics::{Domain, Topic},
     tx_event::TxEvent,
     txs::{
@@ -41,6 +41,7 @@ pub struct Config {
     pub domains: Vec<Domain>,
     /// The whitelist for the Verifier.
     pub whitelist: Whitelist,
+    pub database: db::Config,
 }
 
 /// The Verifier node. It contains the Swarm, the Config, the DB, the JobRunner, and the SecretKey.
@@ -71,7 +72,7 @@ impl VerifierNode {
 
         let config_loader = config::Loader::new("openrank-verifier")?;
         let config: Config = config_loader.load_or_create(include_str!("../config.toml"))?;
-        let db = Db::new("./local-storage", &[&Tx::get_cf()])?;
+        let db = Db::new(&config.database, &[&Tx::get_cf()])?;
         let domain_hashes = config.domains.iter().map(|x| x.to_hash()).collect();
         let job_runner = VerificationJobRunner::new(domain_hashes);
 


### PR DESCRIPTION
Each component that uses RocksDB now gets one config section named [database], which houses all database-related configurations. This commit introduces two database config keys "directory" and "secondary", which are the primary/secondary database directories. They default to "./local-storage" and "./local-secondary-storage" for backward compatibility.