### PR TITLE
feat: persist p2p keypair

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -101,4 +101,8 @@ impl Loader {
     pub fn load_or_create<T: DeserializeOwned>(&self, default: &str) -> Result<T, LoadError> {
         self.load_or_create_named(&self.program_name, default)
     }
+
+    pub fn pathname(&self, filename: &str) -> PathBuf {
+        self.config_dir.join(filename)
+    }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -12,7 +12,7 @@ use alloy_rlp::encode;
 use k256::ecdsa::SigningKey;
 use libp2p::{
     gossipsub::{self, MessageId, PublishError},
-    mdns, noise,
+    identity, mdns, noise,
     swarm::NetworkBehaviour,
     tcp, yamux, Swarm,
 };
@@ -33,8 +33,8 @@ pub struct MyBehaviour {
 }
 
 /// Builds a libp2p swarm with the custom behaviour.
-pub async fn build_node() -> Result<Swarm<MyBehaviour>, Box<dyn Error>> {
-    let swarm = libp2p::SwarmBuilder::with_new_identity()
+pub async fn build_node(keypair: identity::Keypair) -> Result<Swarm<MyBehaviour>, Box<dyn Error>> {
+    let swarm = libp2p::SwarmBuilder::with_existing_identity(keypair)
         .with_tokio()
         .with_tcp(
             tcp::Config::default(),

--- a/common/src/net.rs
+++ b/common/src/net.rs
@@ -1,25 +1,50 @@
 use libp2p::core::transport::ListenerId;
+use libp2p::identity::{DecodingError, Keypair};
 use libp2p::{swarm, Swarm, TransportError};
 use serde::{Deserialize, Serialize};
+use std::io;
+use tracing::info;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("bad listen address {0:?}: {1}")]
     BadListenAddr(String, libp2p::multiaddr::Error),
     #[error("cannot listen on {0:?}: {1}")]
-    CannotListenOn(String, TransportError<std::io::Error>),
+    CannotListenOn(String, TransportError<io::Error>),
+    #[error("cannot read key: {0:?}")]
+    CannotReadKey(io::Error),
+    #[error("cannot write key: {0:?}")]
+    CannotWriteKey(io::Error),
+    #[error("cannot decode key: {0:?}")]
+    CannotDecodeKey(DecodingError),
+    #[error("cannot encode key: {0:?}")]
+    CannotEncodeKey(DecodingError),
 }
 
+/// Network configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub listen_on: Vec<String>,
+    pub keypair: Option<KeypairConfig>,
 }
 
+/// P2P keypair configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeypairConfig {
+    /// Filename of the keypair.  Either absolute or relative to the config directory.
+    /// The file contains binary protobuf representation of the keypair.
+    pub file: Option<String>,
+}
+
+/// Default P2P keypair filename.
+pub const DEFAULT_KEYPAIR_FILENAME: &str = "p2p-keypair.binpb";
+
+/// Makes `swarm` listen on all `multiaddrs` and returns listener identifiers.
 pub fn listen_on<TBehavior: swarm::NetworkBehaviour>(
-    swarm: &mut Swarm<TBehavior>, addrs: &[impl AsRef<str>],
+    swarm: &mut Swarm<TBehavior>, multiaddrs: &[impl AsRef<str>],
 ) -> Result<Vec<ListenerId>, Error> {
     use Error::*;
-    addrs
+    multiaddrs
         .iter()
         .map(|addr| {
             let addr = addr.as_ref();
@@ -28,4 +53,23 @@ pub fn listen_on<TBehavior: swarm::NetworkBehaviour>(
                 .map_err(|e| CannotListenOn(addr.into(), e))
         })
         .collect()
+}
+
+pub fn load_keypair(
+    config: &Option<KeypairConfig>, loader: &crate::config::Loader,
+) -> Result<Keypair, Error> {
+    use Error::*;
+    let filename = config.as_ref().and_then(|c| c.file.as_ref());
+    let path = loader.pathname(filename.map_or(DEFAULT_KEYPAIR_FILENAME, |s| s.as_str()));
+    Ok(match std::fs::read(&path) {
+        Ok(b) => Keypair::from_protobuf_encoding(&b).map_err(CannotDecodeKey)?,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            info!("generating a new p2p keypair");
+            let keypair = Keypair::generate_ed25519();
+            let b = keypair.to_protobuf_encoding().map_err(CannotEncodeKey)?;
+            std::fs::write(&path, b).map_err(CannotWriteKey)?;
+            keypair
+        },
+        Err(e) => return Err(CannotReadKey(e)),
+    })
 }

--- a/computer/src/lib.rs
+++ b/computer/src/lib.rs
@@ -227,8 +227,6 @@ impl ComputerNode {
     pub async fn init() -> Result<Self, Box<dyn Error>> {
         dotenv().ok();
         tracing_subscriber::fmt().with_env_filter(EnvFilter::from_default_env()).init();
-        let swarm = build_node().await?;
-        info!("PEER_ID: {:?}", swarm.local_peer_id());
 
         let secret_key_hex = std::env::var("SECRET_KEY").expect("SECRET_KEY must be set.");
         let secret_key_bytes = hex::decode(secret_key_hex)?;
@@ -240,6 +238,9 @@ impl ComputerNode {
 
         let domain_hashes = config.domains.iter().map(|x| x.to_hash()).collect();
         let job_runner = ComputeJobRunner::new(domain_hashes);
+
+        let swarm = build_node(net::load_keypair(&config.p2p.keypair, &config_loader)?).await?;
+        info!("PEER_ID: {:?}", swarm.local_peer_id());
 
         Ok(Self { swarm, config, db, job_runner, secret_key })
     }

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -65,9 +65,6 @@ impl VerifierNode {
         dotenv().ok();
         tracing_subscriber::fmt().with_env_filter(EnvFilter::from_default_env()).init();
 
-        let swarm = build_node().await?;
-        info!("PEER_ID: {:?}", swarm.local_peer_id());
-
         let secret_key_hex = std::env::var("SECRET_KEY").expect("SECRET_KEY must be set.");
         let secret_key_bytes = hex::decode(secret_key_hex)?;
         let secret_key = SigningKey::from_slice(secret_key_bytes.as_slice())?;
@@ -77,6 +74,9 @@ impl VerifierNode {
         let db = Db::new(&config.database, &[&Tx::get_cf()])?;
         let domain_hashes = config.domains.iter().map(|x| x.to_hash()).collect();
         let job_runner = VerificationJobRunner::new(domain_hashes);
+
+        let swarm = build_node(net::load_keypair(&config.p2p.keypair, &config_loader)?).await?;
+        info!("PEER_ID: {:?}", swarm.local_peer_id());
 
         Ok(Self { swarm, config, db, job_runner, secret_key })
     }


### PR DESCRIPTION
By default, it is stored/loaded back from
~/.config/openrank-XXX/p2p-keypair.binpb (XXX is the program name). The location can be changed using the p2p.keypair.file config variable.

The content is in binary (serialized) protobuf format.