### PR TITLE
feat: bump MSRV to 1.79

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.79.0"
 components = ["rustfmt", "clippy", "rust-analysis"]
 targets = ["aarch64-apple-darwin"]


### PR DESCRIPTION
This is in preparation for the smart contract PR.