### PR TITLE
chore: add MSRV 1.82

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
     "da",
     "openrank-sdk",
     "verifier",
-    "relayer"
+    "relayer",
 ]
 
 [workspace.package]
@@ -19,6 +19,7 @@ authors = [
 ]
 edition = "2021"
 license = "MIT"
+rust-version = "1.82"
 
 [workspace.dependencies]
 openrank-sequencer = { path = "sequencer", version = "0.1.0" }

--- a/block-builder/Cargo.toml
+++ b/block-builder/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openrank-block-builder"
 description = "OpenRank - Block Builder Node"
-rust-version = "1.82"
+rust-version.workspace = true
 license.workspace = true
 version.workspace = true
 authors.workspace = true

--- a/block-builder/Cargo.toml
+++ b/block-builder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "openrank-block-builder"
 description = "OpenRank - Block Builder Node"
+rust-version = "1.82"
 license.workspace = true
 version.workspace = true
 authors.workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "openrank-common"
 description = "Common library for OpenRank codebase"
+rust-version = "1.82"
 license.workspace = true
 version.workspace = true
 authors.workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openrank-common"
 description = "Common library for OpenRank codebase"
-rust-version = "1.82"
+rust-version.workspace = true
 license.workspace = true
 version.workspace = true
 authors.workspace = true

--- a/computer/Cargo.toml
+++ b/computer/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "openrank-computer"
 description = "OpenRank - Computer Node"
+rust-version = "1.82"
 license.workspace = true
 version.workspace = true
 authors.workspace = true

--- a/computer/Cargo.toml
+++ b/computer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openrank-computer"
 description = "OpenRank - Computer Node"
-rust-version = "1.82"
+rust-version.workspace = true
 license.workspace = true
 version.workspace = true
 authors.workspace = true

--- a/da/Cargo.toml
+++ b/da/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openrank-da"
 description = "DA wrapper for OpenRank codebase"
-rust-version = "1.82"
+rust-version.workspace = true
 license = "MIT"
 version.workspace = true
 authors.workspace = true

--- a/da/Cargo.toml
+++ b/da/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "openrank-da"
 description = "DA wrapper for OpenRank codebase"
+rust-version = "1.82"
 license = "MIT"
 version.workspace = true
 authors.workspace = true

--- a/openrank-sdk/Cargo.toml
+++ b/openrank-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openrank-sdk"
 description = "OpenRank - SDK"
-rust-version = "1.82"
+rust-version.workspace = true
 license.workspace = true
 version.workspace = true
 authors.workspace = true

--- a/openrank-sdk/Cargo.toml
+++ b/openrank-sdk/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "openrank-sdk"
 description = "OpenRank - SDK"
+rust-version = "1.82"
 license.workspace = true
 version.workspace = true
 authors.workspace = true

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "openrank-relayer"
 description = "OpenRank - Relayer"
+rust-version = "1.82"
 license.workspace = true
 version.workspace = true
 authors.workspace = true

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openrank-relayer"
 description = "OpenRank - Relayer"
-rust-version = "1.82"
+rust-version.workspace = true
 license.workspace = true
 version.workspace = true
 authors.workspace = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.82.0"
 components = ["rustfmt", "clippy", "rust-analysis"]
 targets = ["aarch64-apple-darwin"]

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openrank-sequencer"
 description = "OpenRank - Sequencer Node"
-rust-version = "1.82"
+rust-version.workspace = true
 license.workspace = true
 version.workspace = true
 authors.workspace = true

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "openrank-sequencer"
 description = "OpenRank - Sequencer Node"
+rust-version = "1.82"
 license.workspace = true
 version.workspace = true
 authors.workspace = true

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "openrank-verifier"
 description = "OpenRank - Verifier Node"
+rust-version = "1.82"
 license.workspace = true
 version.workspace = true
 authors.workspace = true

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openrank-verifier"
 description = "OpenRank - Verifier Node"
-rust-version = "1.82"
+rust-version.workspace = true
 license.workspace = true
 version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Resolves #142.

```
   Compiling idna v1.0.3
error[E0658]: use of unstable library feature 'error_in_core'
  --> /home/ubuntu/.cargo/registry/src/index.crates.io-6f17d22bba15001f/idna-1.0.3/src/lib.rs:78:6
   |
78 | impl core::error::Error for Errors {}
   |      ^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #103765 <https://github.com/rust-lang/rust/issues/103765> for more information
```

## Changes
- Added `rust_version = "1.82"` to crate-level Cargo.toml.

## Reminders
- [x] Add a prefix to PR: `feat:` (for features), `ref:` (for refactoring), `bug:` (for bug fixes)
- [x] Assign reviewers
- [x] Link related issues
- [x] Make it draft if it is still WIP
- [x] Write unit tests for your code if possible
- [x] Make sure your code work as intended and doesn't break the rest of the codebase
