### PR TITLE
feat: use BTreeMap for LocalTrust and SeedTrust

### DIFF
--- a/common/src/algos/et.rs
+++ b/common/src/algos/et.rs
@@ -176,7 +176,9 @@ pub fn is_converged(scores: &BTreeMap<u64, f32>, next_scores: &BTreeMap<u64, f32
 }
 
 /// Same as `is_converged`, but accepts the scores map in it's original form, where peers are identified by a `String`.
-pub fn is_converged_org(scores: &BTreeMap<String, f32>, next_scores: &BTreeMap<String, f32>) -> bool {
+pub fn is_converged_org(
+    scores: &BTreeMap<String, f32>, next_scores: &BTreeMap<String, f32>,
+) -> bool {
     scores
         .par_iter()
         .fold(

--- a/common/src/misc.rs
+++ b/common/src/misc.rs
@@ -1,7 +1,7 @@
 use base64::prelude::*;
 use getset::Getters;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use crate::{
     runners::Error as BaseRunnerError,
@@ -23,7 +23,7 @@ pub struct OutboundLocalTrust {
     /// assigns to its peers. The trust values are represented as a vector of
     /// floats, where each element in the vector corresponds to the trust value
     /// assigned to a particular peer.
-    outbound_trust_scores: HashMap<u64, f32>,
+    outbound_trust_scores: BTreeMap<u64, f32>,
     /// The sum of the trust values assigned to all peers.
     ///
     /// The `outbound_sum` value stores the sum of the trust values assigned to
@@ -40,15 +40,15 @@ impl Default for OutboundLocalTrust {
 
 impl OutboundLocalTrust {
     pub fn new() -> Self {
-        Self { outbound_trust_scores: HashMap::new(), outbound_sum: 0.0 }
+        Self { outbound_trust_scores: BTreeMap::new(), outbound_sum: 0.0 }
     }
 
-    pub fn set_outbound_trust_scores(&mut self, outbound_trust_scores: HashMap<u64, f32>) {
+    pub fn set_outbound_trust_scores(&mut self, outbound_trust_scores: BTreeMap<u64, f32>) {
         self.outbound_trust_scores = outbound_trust_scores;
         self.outbound_sum = self.outbound_trust_scores.values().sum();
     }
 
-    pub fn from_score_map(score_map: &HashMap<u64, f32>) -> Self {
+    pub fn from_score_map(score_map: &BTreeMap<u64, f32>) -> Self {
         let outbound_trust_scores = score_map.clone();
         let outbound_sum = outbound_trust_scores.values().sum();
         Self { outbound_trust_scores, outbound_sum }
@@ -63,7 +63,7 @@ impl OutboundLocalTrust {
         OutboundLocalTrust { outbound_trust_scores, outbound_sum }
     }
 
-    /*----------------- HashMap similar utils -----------------*/
+    /*----------------- BTreeMap similar utils -----------------*/
     pub fn get(&self, peer_id: &u64) -> Option<f32> {
         self.outbound_trust_scores.get(peer_id).copied()
     }

--- a/common/src/runners/mod.rs
+++ b/common/src/runners/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use getset::Getters;
 use sha3::Keccak256;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use tracing::info;
 
 pub mod compute_runner;
@@ -21,8 +21,8 @@ pub struct BaseRunner {
     count: HashMap<DomainHash, u64>,
     indices: HashMap<DomainHash, HashMap<String, u64>>,
     rev_indices: HashMap<DomainHash, HashMap<u64, String>>,
-    local_trust: HashMap<OwnedNamespace, HashMap<u64, OutboundLocalTrust>>,
-    seed_trust: HashMap<OwnedNamespace, HashMap<u64, f32>>,
+    local_trust: HashMap<OwnedNamespace, BTreeMap<u64, OutboundLocalTrust>>,
+    seed_trust: HashMap<OwnedNamespace, BTreeMap<u64, f32>>,
     lt_sub_trees: HashMap<DomainHash, HashMap<u64, DenseIncrementalMerkleTree<Keccak256>>>,
     lt_master_tree: HashMap<DomainHash, DenseIncrementalMerkleTree<Keccak256>>,
     st_master_tree: HashMap<DomainHash, DenseIncrementalMerkleTree<Keccak256>>,
@@ -44,8 +44,8 @@ impl BaseRunner {
             count.insert(domain_hash, 0);
             indices.insert(domain_hash, HashMap::new());
             rev_indices.insert(domain_hash, HashMap::new());
-            local_trust.insert(domain.trust_namespace(), HashMap::new());
-            seed_trust.insert(domain.trust_namespace(), HashMap::new());
+            local_trust.insert(domain.trust_namespace(), BTreeMap::new());
+            seed_trust.insert(domain.trust_namespace(), BTreeMap::new());
             lt_sub_trees.insert(domain_hash, HashMap::new());
             lt_master_tree.insert(
                 domain_hash,

--- a/common/src/runners/verification_runner.rs
+++ b/common/src/runners/verification_runner.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use getset::Getters;
 use sha3::Keccak256;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use tracing::info;
 
 use super::{BaseRunner, Error as BaseError};
@@ -245,11 +245,11 @@ impl VerificationRunner {
             }
             scores
         };
-        let score_entries: HashMap<u64, f32> = {
+        let score_entries: BTreeMap<u64, f32> = {
             let score_entries_vec: Vec<ScoreEntry> =
                 scores.iter().flat_map(|cs| cs.entries().clone()).collect();
 
-            let mut score_entries_map: HashMap<u64, f32> = HashMap::new();
+            let mut score_entries_map: BTreeMap<u64, f32> = BTreeMap::new();
             for entry in score_entries_vec {
                 let i = domain_indices
                     .get(entry.id())

--- a/openrank-sdk/src/lib.rs
+++ b/openrank-sdk/src/lib.rs
@@ -20,7 +20,7 @@ use openrank_common::{
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 use sha3::Keccak256;
-use std::{cmp::Ordering, collections::HashMap, fs::File, io::Read};
+use std::{cmp::Ordering, collections::BTreeMap, fs::File, io::Read};
 use std::{io, num};
 
 const TRUST_CHUNK_SIZE: usize = 500;
@@ -501,12 +501,12 @@ impl OpenRankSDK {
     pub fn check_score_integrity(
         votes: Vec<bool>, computed_scores: Vec<ScoreEntry>, correct_scores: Vec<ScoreEntry>,
     ) -> Result<bool, SdkError> {
-        let mut computed_scores_map = HashMap::new();
+        let mut computed_scores_map = BTreeMap::new();
         for score in computed_scores {
             computed_scores_map.insert(score.id().clone(), *score.value());
         }
 
-        let mut correct_scores_map = HashMap::new();
+        let mut correct_scores_map = BTreeMap::new();
         for score in correct_scores {
             correct_scores_map.insert(score.id().clone(), *score.value());
         }


### PR DESCRIPTION
## Changes
- use the `BTreeMap` instead of `HashMap` in `BaseRunner::local/seed_trust`
- update the codebase accordingly

Closes #185 

## Reminders
- [x] Add a prefix to PR: `feat:` (for features), `chore:` (for chores/refactoring), `fix:` (for bug fixes), or any from: https://www.conventionalcommits.org/en/v1.0.0/#summary
- [x] Assign reviewers
- [x] Link related issues
- [x] Make it draft if it is still WIP
- [x] Write unit tests for your code if possible
- [x] Do manual testing and make sure your changes don't break the rest of the codebase
